### PR TITLE
Add support for `access_token` query string as part of POP protocol

### DIFF
--- a/cashweb-auth-wrapper/Cargo.toml
+++ b/cashweb-auth-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cashweb-auth-wrapper"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 authors = ["Harry Barber <harrybarber@protonmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/cashweb-token/src/lib.rs
+++ b/cashweb-token/src/lib.rs
@@ -15,25 +15,43 @@ use http::header::{HeaderMap, HeaderValue, AUTHORIZATION};
 
 /// Extract a POP token from `Authorization` header.
 pub fn extract_pop_header(value: &HeaderValue) -> Option<&str> {
-    if let Ok(header_str) = value.to_str() {
-        return Some(header_str);
-    }
-    None
+    value.to_str().ok().and_then(split_pop_token)
 }
 
-fn split_pop_token(full_token: &str) -> Option<&str> {
-    if &full_token[..4] == "POP " {
-        return Some(&full_token[4..]);
+/// Split the POP token, removing the prefix "POP".
+pub fn split_pop_token(full_token: &str) -> Option<&str> {
+    if full_token.len() > 4 {
+        if &full_token[..4] == "POP " {
+            return Some(&full_token[4..]);
+        }
     }
     None
 }
 
 /// Extract the first POP token from [`HeaderMap`].
-pub fn extract_pop<'a>(headers: &'a HeaderMap, query_token: &'a Option<String>) -> Option<&'a str> {
+pub fn extract_pop(headers: &HeaderMap) -> Option<&str> {
     headers
         .get_all(AUTHORIZATION)
         .iter()
         .find_map(extract_pop_header)
-        .or_else(|| query_token.as_ref().map(|token| &token[..]))
-        .and_then(split_pop_token)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_split_ok() {
+        split_pop_token("POP abc").unwrap();
+    }
+
+    #[test]
+    fn test_split_short() {
+        assert_eq!(split_pop_token("A"), None);
+    }
+
+    #[test]
+    fn test_split_err() {
+        assert_eq!(split_pop_token("ABC d"), None);
+    }
 }

--- a/cashweb-token/src/lib.rs
+++ b/cashweb-token/src/lib.rs
@@ -20,10 +20,8 @@ pub fn extract_pop_header(value: &HeaderValue) -> Option<&str> {
 
 /// Split the POP token, removing the prefix "POP".
 pub fn split_pop_token(full_token: &str) -> Option<&str> {
-    if full_token.len() > 4 {
-        if &full_token[..4] == "POP " {
-            return Some(&full_token[4..]);
-        }
+    if full_token.len() > 4 && &full_token[..4] == "POP " {
+        return Some(&full_token[4..]);
     }
     None
 }

--- a/cashweb-token/src/lib.rs
+++ b/cashweb-token/src/lib.rs
@@ -16,20 +16,24 @@ use http::header::{HeaderMap, HeaderValue, AUTHORIZATION};
 /// Extract a POP token from `Authorization` header.
 pub fn extract_pop_header(value: &HeaderValue) -> Option<&str> {
     if let Ok(header_str) = value.to_str() {
-        if &header_str[..4] == "POP " {
-            Some(&header_str[4..])
-        } else {
-            None
-        }
-    } else {
-        None
+        return Some(header_str);
     }
+    None
+}
+
+fn split_pop_token(full_token: &str) -> Option<&str> {
+    if &full_token[..4] == "POP " {
+        return Some(&full_token[4..]);
+    }
+    None
 }
 
 /// Extract the first POP token from [`HeaderMap`].
-pub fn extract_pop(headers: &HeaderMap) -> Option<&str> {
+pub fn extract_pop<'a>(headers: &'a HeaderMap, query_token: &'a Option<String>) -> Option<&'a str> {
     headers
         .get_all(AUTHORIZATION)
         .iter()
         .find_map(extract_pop_header)
+        .or_else(|| query_token.as_ref().map(|token| &token[..]))
+        .and_then(split_pop_token)
 }

--- a/cashweb/Cargo.toml
+++ b/cashweb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cashweb"
-version = "0.1.0-alpha.7"
+version = "0.1.0-alpha.8"
 authors = ["Harry Barber <harrybarber@protonmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -11,7 +11,7 @@ description = "A collection of useful cash:web helper libraries."
 categories = ["development-tools"]
 
 [dependencies]
-auth-wrapper = { version = "0.1.0-alpha.3", package = "cashweb-auth-wrapper", path = "../cashweb-auth-wrapper" }
+auth-wrapper = { version = "0.1.0-alpha.4", package = "cashweb-auth-wrapper", path = "../cashweb-auth-wrapper" }
 bitcoin = { version = "0.1.0-alpha.3", package = "cashweb-bitcoin", path = "../cashweb-bitcoin" }
 bitcoin-client = { version = "0.1.0-alpha.4", package = "cashweb-bitcoin-client", path = "../cashweb-bitcoin-client" }
 keyserver = { version = "0.1.0-alpha.3", package = "cashweb-keyserver", path = "../cashweb-keyserver" }


### PR DESCRIPTION
Access_token needs to be supported in order for the websocket connection
to success from a web browser. The API within web browsers cannot set
custom headers. So, this is the workaround provided for now until
the API for web browsers is updated somehow to allow for setting
bearer tokens in the auth headers.

See: https://tools.ietf.org/html/rfc6750#section-2.3